### PR TITLE
fix: 🐛 ignore fake process global defined in Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var microtaskProcessNextTick = typeof process === 'object'
+var microtaskProcessNextTick = ((typeof process === 'object') && !process.browser)
   ? process.nextTick || null
   : null;
 

--- a/lite.js
+++ b/lite.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var microtaskProcessNextTick = typeof process === 'object'
+var microtaskProcessNextTick = ((typeof process === 'object') && !process.browser)
   ? process.nextTick || null
   : null;
 


### PR DESCRIPTION
It uses its own implementation of process.nextTick() which is not
compatible with Node.js